### PR TITLE
feat: Add ASCII art pack for game elements

### DIFF
--- a/assets/ascii/.keep
+++ b/assets/ascii/.keep
@@ -1,0 +1,1 @@
+# This file is used to ensure the directory is tracked by Git.

--- a/assets/ascii/quick-art.js
+++ b/assets/ascii/quick-art.js
@@ -1,0 +1,43 @@
+const quickArt = {
+  farmHeader: `
+  ---------------------
+  |    F A R M        |
+  |   G A M E         |
+  |   H E A D E R     |
+  ---------------------
+  `,
+  barn: `
+    /\\_______/\\
+   |  _______  |
+   | |       | |
+   | |       | |
+   |_|_______|_|
+  `,
+  field: `
+  ~~~~~~~~~~~~~~~~~~~~~
+  ~  F I E L D        ~
+  ~  v V v V v V v    ~
+  ~   V v V v V v     ~
+  ~~~~~~~~~~~~~~~~~~~~~
+  `,
+  goat: `
+    (\ /)
+  __(o.o)__
+    /_"\\_\\
+  `,
+  victoryScreen: `
+  **************************
+  *                        *
+  *    V I C T O R Y !     *
+  *                        *
+  *   You found the G.O.A.T! *
+  *                        *
+  *                        *
+  **************************
+  `,
+};
+
+// Export the object for use in other parts of the game
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = quickArt;
+}


### PR DESCRIPTION
I've created `assets/ascii/quick-art.js` with the following ASCII art for you:
- Farm header (5 lines)
- Barn (5 lines)
- Field (5 lines)
- Goat (3 lines)
- Victory screen (8 lines)

This art is for use in your GOAT Mystery game.